### PR TITLE
[Bug Fix] Dictionaries may contain inner lists as values per RFC8941.

### DIFF
--- a/http_sf/dictionary.py
+++ b/http_sf/dictionary.py
@@ -1,7 +1,6 @@
 from typing import Tuple, cast
 
-from http_sf.item import ser_item
-from http_sf.innerlist import parse_item_or_inner_list
+from http_sf.innerlist import parse_item_or_inner_list, ser_item_or_inner_list
 from http_sf.parameters import parse_params, ser_params
 from http_sf.types import DictionaryType, ItemType
 from http_sf.util import discard_http_ows, ser_key, parse_key
@@ -50,7 +49,7 @@ def ser_dictionary(dictionary: DictionaryType) -> str:
             f"{ser_key(m)}"
             f"""{ser_params(n[1]) if
                 (isinstance(n, tuple) and n[0] is True)
-                else f'={ser_item(cast(ItemType, n))}'}"""
+                else f'={ser_item_or_inner_list(cast(ItemType, n))}'}"""
             for m, n in dictionary.items()
         ]
     )


### PR DESCRIPTION
Per RFC8941, Dictionaries may contain inner lists as values of keys. 

In RFC8941, the syntax of dictionary is as follows.

```
sf-dictionary  = dict-member *( OWS "," OWS dict-member )
dict-member    = member-key ( parameters / ( "=" member-value ))
member-key     = key
member-value   = sf-item / inner-list
```

However, in `http_sf/dictionary.py`, dictionary serialization only allows items, but it does not include inner lists.

```python3
def ser_dictionary(dictionary: DictionaryType) -> str:
    if len(dictionary) == 0:
        raise ValueError("No contents; field should not be emitted")
    return ", ".join(
        [
            f"{ser_key(m)}"
            f"""{ser_params(n[1]) if
                (isinstance(n, tuple) and n[0] is True)
                else f'={ser_item(cast(ItemType, n))}'}""" # ser_item is able to handle only lists.
            for m, n in dictionary.items()
        ]
    )
```

As a result, the following is not serializable.
```python3
Python 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import http_sf
>>> http_sf.ser({"a": (["x"], {"p": 1})})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/orangecalculator/http-sf/http_sf/__init__.py", line 63, in ser
    return ser_dictionary(structure)
  File "/home/orangecalculator/http-sf/http_sf/dictionary.py", line 49, in ser_dictionary
    [
  File "/home/orangecalculator/http-sf/http_sf/dictionary.py", line 53, in <listcomp>
    else f'={ser_item(cast(ItemType, n))}'}"""
  File "/home/orangecalculator/http-sf/http_sf/item.py", line 22, in ser_item
    return f"{ser_bare_item(item[0])}{ser_params(item[1])}"
  File "/home/orangecalculator/http-sf/http_sf/bare_item.py", line 61, in ser_bare_item
    raise ValueError(f"Can't serialise; unrecognised item with type {type(item)}")
ValueError: Can't serialise; unrecognised item with type <class 'list'>
```

After this commit, the bug is fixed.
```python3
Python 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import http_sf
>>> http_sf.ser({"a": (["x"], {"p": 1})})
'a=("x");p=1'
```