### PR TITLE
Fixed: ValueError for early dates by using UTC in fromtimestamp()

### DIFF
--- a/http_sf/date.py
+++ b/http_sf/date.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from .errors import StructuredFieldError
 from .integer import parse_integer
@@ -12,7 +12,7 @@ def parse_date(state: ParserState) -> datetime:
         raise StructuredFieldError(
             "Non-integer Date", position=state.cursor, offending_char=None
         )
-    return datetime.fromtimestamp(value)
+    return datetime.fromtimestamp(value, tz=timezone.utc)
 
 
 def ser_date(inval: datetime) -> str:

--- a/http_sf/util.py
+++ b/http_sf/util.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from string import ascii_lowercase, ascii_uppercase, digits
 from typing import Any
@@ -115,7 +115,7 @@ def json_load(inobj: JsonDict) -> Any:
     if objtype == "binary":
         return base64.b32decode(inobj["value"])
     if objtype == "date":
-        return datetime.fromtimestamp(inobj["value"])
+        return datetime.fromtimestamp(inobj["value"], tz=timezone.utc)
     if objtype == "displaystring":
         return DisplayString(inobj["value"])
     raise ValueError(f"Unknown object type - {inobj}")


### PR DESCRIPTION
datetime.fromtimestamp() without a timezone uses local time, which pushes dates like 0001-01-01 before year 1 depending on the local timezone offset. Passing tz=timezone.utc avoids the adjustment and correctly handles the full date range.