### PR TITLE
Fix: StructuredFieldError contract violations in parse_date and parse_number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ TESTS=test/tests/*.json
 test: $(TESTS) venv
 	PYTHONPATH=.:$(VENV) $(VENV)/python test/test.py $(TESTS)
 	PYTHONPATH=.:$(VENV) $(VENV)/python test/test_position.py
+	PYTHONPATH=.:$(VENV) $(VENV)/python test/test_error_contract.py
 
 $(TESTS):
 	git submodule update --init --recursive

--- a/http_sf/date.py
+++ b/http_sf/date.py
@@ -12,7 +12,12 @@ def parse_date(state: ParserState) -> datetime:
         raise StructuredFieldError(
             "Non-integer Date", position=state.cursor, offending_char=None
         )
-    return datetime.fromtimestamp(value, tz=timezone.utc)
+    try:
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    except (ValueError, OSError) as why:
+        raise StructuredFieldError(
+            "Date value out of range", position=state.cursor, offending_char=None
+        ) from why
 
 
 def ser_date(inval: datetime) -> str:

--- a/http_sf/integer.py
+++ b/http_sf/integer.py
@@ -61,7 +61,9 @@ def parse_number(state: ParserState) -> Union[int, Decimal]:
         elif _type is INTEGER and char == PERIOD:
             # spec says 12, but character is appended afterwards
             if num_length > 13:
-                raise ValueError("Decimal too long.")
+                raise StructuredFieldError(
+                    "Decimal too long.", position=state.cursor, offending_char=None
+                )
         state.cursor += 1
         num_length = state.cursor - num_start - 1
         if char in DIGITS:

--- a/test/test_error_contract.py
+++ b/test/test_error_contract.py
@@ -1,0 +1,69 @@
+"""
+Tests that all parse errors raise StructuredFieldError, never bare ValueError
+or OSError, regardless of input. Covers cases where the SF integer range
+permits values that downstream Python APIs reject.
+"""
+import sys
+from http_sf import parse, StructuredFieldError
+
+
+def test_date_out_of_range():
+    print("Testing out-of-range Date values raise StructuredFieldError...")
+
+    # Max SF integer — year ~31 million, far outside datetime's year 1-9999 range
+    try:
+        parse(b"@999999999999999", tltype="item")
+        print("  Test 1: FAIL (no exception raised)")
+        sys.exit(1)
+    except StructuredFieldError:
+        print("  Test 1: OK (large positive timestamp)")
+    except (ValueError, OSError) as e:
+        print(f"  Test 1: FAIL (wrong exception type {type(e).__name__}: {e})")
+        sys.exit(1)
+
+    # Min SF integer — far before year 1
+    try:
+        parse(b"@-999999999999999", tltype="item")
+        print("  Test 2: FAIL (no exception raised)")
+        sys.exit(1)
+    except StructuredFieldError:
+        print("  Test 2: OK (large negative timestamp)")
+    except (ValueError, OSError) as e:
+        print(f"  Test 2: FAIL (wrong exception type {type(e).__name__}: {e})")
+        sys.exit(1)
+
+    print("All Date out-of-range tests passed.")
+
+
+def test_decimal_too_long():
+    print("Testing overlong decimal integer part raises StructuredFieldError...")
+
+    # 14 digits before decimal point — exceeds the 12-digit SF limit
+    try:
+        parse(b"12345678901234.1", tltype="item")
+        print("  Test 1: FAIL (no exception raised)")
+        sys.exit(1)
+    except StructuredFieldError:
+        print("  Test 1: OK (14-digit integer part)")
+    except ValueError as e:
+        print(f"  Test 1: FAIL (wrong exception type ValueError: {e})")
+        sys.exit(1)
+
+    # Exactly at the boundary — 13 digits before decimal (also invalid per spec)
+    try:
+        parse(b"1234567890123.1", tltype="item")
+        print("  Test 2: FAIL (no exception raised)")
+        sys.exit(1)
+    except StructuredFieldError:
+        print("  Test 2: OK (13-digit integer part)")
+    except ValueError as e:
+        print(f"  Test 2: FAIL (wrong exception type ValueError: {e})")
+        sys.exit(1)
+
+    print("All Decimal too-long tests passed.")
+
+
+if __name__ == "__main__":
+    test_date_out_of_range()
+    print()
+    test_decimal_too_long()


### PR DESCRIPTION

Two parsing paths raised bare `ValueError` (or `OSError`) instead of `StructuredFieldError` for certain attacker-reachable inputs, breaking the documented error contract.

**parse_date** (`date.py`): `datetime.fromtimestamp()` raises `ValueError` or `OSError` for timestamps outside Python's year 1–9999 range, but the SF integer range permits values up to ±999,999,999,999,999. A header like `@999999999999999` would escape as a bare exception. The fix wraps the call in a `try/except (ValueError, OSError)` and re-raises as `StructuredFieldError`, matching the pattern already used in `util.py:json_load`.

**parse_number** (`integer.py`): There were two length checks for the integer part of a decimal value. The post-advance check correctly raised `StructuredFieldError`; the pre-advance check (triggering when num_length > 13) raised a bare `ValueError`. A decimal with 14+ integer digits would escape. The fix makes the first check consistent with the second.

Both fixes are covered by a new `test/test_error_contract.py`, added to the `make test` target.