### PR TITLE
Added: http_sf.compat backwards-compatibility layer for http_sfv users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ TESTS=test/tests/*.json
 .PHONY: test
 test: $(TESTS) venv
 	PYTHONPATH=.:$(VENV) $(VENV)/python test/test.py $(TESTS)
+	PYTHONPATH=.:$(VENV) $(VENV)/python test/test_compat_full.py $(TESTS)
 	PYTHONPATH=.:$(VENV) $(VENV)/python test/test_position.py
 	PYTHONPATH=.:$(VENV) $(VENV)/python test/test_error_contract.py
 	PYTHONPATH=.:$(VENV) $(VENV)/python test/test_compat.py

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ test: $(TESTS) venv
 	PYTHONPATH=.:$(VENV) $(VENV)/python test/test.py $(TESTS)
 	PYTHONPATH=.:$(VENV) $(VENV)/python test/test_position.py
 	PYTHONPATH=.:$(VENV) $(VENV)/python test/test_error_contract.py
+	PYTHONPATH=.:$(VENV) $(VENV)/python test/test_compat.py
 
 $(TESTS):
 	git submodule update --init --recursive

--- a/README.md
+++ b/README.md
@@ -117,6 +117,21 @@ When using `ser`, if an Item or Inner List doesn't have parameters, they can be 
 Note that `ser` produces a string, not a bytes-like object.
 
 
+## Migrating from `http_sfv`
+
+If you have code that uses the deprecated [http_sfv](https://pypi.org/project/http-sfv/) package, a drop-in compatibility layer is available in `http_sf.compat`. It provides the same object-oriented `Dictionary`, `List`, `Item`, `InnerList`, `Token`, and `DisplayString` classes built on top of this library's functional API, so existing code typically only needs an import change:
+
+~~~ python
+# Before
+from http_sfv import Dictionary, List, Item, Token
+
+# After
+from http_sf.compat import Dictionary, List, Item, Token
+~~~
+
+The compat layer exposes the same `.parse(bytes)` / `str(...)` workflow, `.value` / `.params` attributes, structural list/dict behaviour, and Item equality semantics (compared by value, ignoring parameters) as `http_sfv`. New code should prefer the functional `parse` / `ser` API documented above.
+
+
 ## Command Line Use
 
 You can validate and examine the data model of a field value by calling the library on the command line, using `-d`, `-l` and `-i` to denote dictionaries, lists or items respectively; e.g.,

--- a/http_sf/compat.py
+++ b/http_sf/compat.py
@@ -1,0 +1,203 @@
+"""
+Backwards-compatibility layer that mimics the object-oriented API of the
+deprecated http_sfv package on top of http_sf's functional API.
+
+Allows existing http_sfv users to migrate by changing only their imports:
+
+    from http_sf.compat import Dictionary, List, Item, InnerList, Token, DisplayString
+"""
+
+from collections import UserDict, UserList
+from typing import (
+    Any,
+    Dict as _Dict,
+    Iterable,
+    List as _List,
+    Mapping,
+    Optional,
+    Union,
+)
+
+from typing_extensions import SupportsIndex
+
+from . import parse as _parse, ser as _ser
+from .innerlist import ser_innerlist
+from .item import ser_item
+from .parameters import ser_params
+from .types import (
+    BareItemType,
+    DisplayString,
+    Token,
+)
+
+__all__ = [
+    "Dictionary",
+    "List",
+    "Item",
+    "InnerList",
+    "Parameters",
+    "Token",
+    "DisplayString",
+    "structures",
+]
+
+
+class Parameters(dict):  # type: ignore[type-arg]
+    """Parameter mapping with structured-field serialisation."""
+
+    def __str__(self) -> str:
+        return ser_params(self)
+
+
+SingleItemType = Union[BareItemType, "Item"]
+
+
+class Item:
+    """A bare Item with optional Parameters."""
+
+    def __init__(self, value: Optional[BareItemType] = None) -> None:
+        self.value: Optional[BareItemType] = value
+        self.params: Parameters = Parameters()
+
+    def parse(self, data: bytes) -> None:
+        result = _parse(data, tltype="item")
+        assert isinstance(result, tuple)
+        value, params = result
+        self.value = value
+        self.params = Parameters(params)
+
+    def __str__(self) -> str:
+        return ser_item((self.value, dict(self.params)))  # type: ignore[arg-type]
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, Item):
+            return bool(self.value == other.value)
+        return bool(self.value == other)
+
+    def __ne__(self, other: Any) -> bool:
+        return not self.__eq__(other)
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+    def __repr__(self) -> str:
+        return f"<http_sf.compat.Item value={self.value!r} params={dict(self.params)!r}>"
+
+
+AllItemType = Union[BareItemType, Item, "InnerList", _List[Any]]
+
+
+def _itemise(thing: AllItemType) -> Union[Item, "InnerList"]:
+    if isinstance(thing, (Item, InnerList)):
+        return thing
+    if isinstance(thing, list):
+        return InnerList(thing)
+    return Item(thing)
+
+
+def _to_functional(thing: Union[Item, "InnerList"]) -> Any:
+    if isinstance(thing, InnerList):
+        members = [_to_functional(i) for i in thing.data]
+        return (members, dict(thing.params))
+    return (thing.value, dict(thing.params))
+
+
+def _from_functional(value: Any) -> Union[Item, "InnerList"]:
+    if isinstance(value, tuple):
+        inner, params = value
+        if isinstance(inner, list):
+            il = InnerList()
+            for elem in inner:
+                il.data.append(_from_functional(elem))
+            il.params = Parameters(params)
+            return il
+        item = Item(inner)
+        item.params = Parameters(params)
+        return item
+    # bare value (shouldn't typically happen from parse, but ser accepts it)
+    return Item(value)
+
+
+class InnerList(UserList):  # type: ignore[type-arg]
+    def __init__(self, values: Optional[Iterable[AllItemType]] = None) -> None:
+        UserList.__init__(self, [_itemise(v) for v in values or []])
+        self.params: Parameters = Parameters()
+
+    def __str__(self) -> str:
+        members = [_to_functional(i) for i in self.data]
+        return ser_innerlist((members, dict(self.params)))
+
+    def __setitem__(
+        self,
+        index: Union[SupportsIndex, slice],
+        value: Union[AllItemType, Iterable[AllItemType]],
+    ) -> None:
+        if isinstance(index, slice):
+            self.data[index] = [_itemise(v) for v in value]  # type: ignore[union-attr]
+        else:
+            self.data[index] = _itemise(value)  # type: ignore[arg-type]
+
+    def append(self, item: AllItemType) -> None:
+        self.data.append(_itemise(item))
+
+    def insert(self, i: int, item: AllItemType) -> None:
+        self.data.insert(i, _itemise(item))
+
+
+class Dictionary(UserDict):  # type: ignore[type-arg]
+    def __init__(
+        self, data: Optional[Mapping[str, AllItemType]] = None
+    ) -> None:
+        UserDict.__init__(self)
+        if data is not None:
+            for key, val in data.items():
+                self[key] = val
+
+    def parse(self, data: bytes) -> None:
+        parsed: _Dict[str, Any] = _parse(data, tltype="dictionary")  # type: ignore[assignment]
+        self.data.clear()
+        for key, val in parsed.items():
+            self.data[key] = _from_functional(val)
+
+    def __setitem__(self, key: str, value: AllItemType) -> None:
+        self.data[key] = _itemise(value)
+
+    def __str__(self) -> str:
+        if not self.data:
+            raise ValueError("No contents; field should not be emitted")
+        return _ser({k: _to_functional(v) for k, v in self.data.items()})
+
+
+class List(UserList):  # type: ignore[type-arg]
+    def __init__(self, values: Optional[Iterable[AllItemType]] = None) -> None:
+        UserList.__init__(self, [_itemise(v) for v in values or []])
+
+    def parse(self, data: bytes) -> None:
+        parsed: _List[Any] = _parse(data, tltype="list")  # type: ignore[assignment]
+        self.data.clear()
+        for elem in parsed:
+            self.data.append(_from_functional(elem))
+
+    def __str__(self) -> str:
+        if not self.data:
+            raise ValueError("No contents; field should not be emitted")
+        return _ser([_to_functional(v) for v in self.data])
+
+    def __setitem__(
+        self,
+        index: Union[SupportsIndex, slice],
+        value: Union[AllItemType, Iterable[AllItemType]],
+    ) -> None:
+        if isinstance(index, slice):
+            self.data[index] = [_itemise(v) for v in value]  # type: ignore[union-attr]
+        else:
+            self.data[index] = _itemise(value)  # type: ignore[arg-type]
+
+    def append(self, item: AllItemType) -> None:
+        self.data.append(_itemise(item))
+
+    def insert(self, i: int, item: AllItemType) -> None:
+        self.data.insert(i, _itemise(item))
+
+
+structures = {"dictionary": Dictionary, "list": List, "item": Item}

--- a/test/test_compat.py
+++ b/test/test_compat.py
@@ -1,0 +1,129 @@
+"""Tests for the http_sfv-compatible API exposed by http_sf.compat."""
+
+import unittest
+
+from http_sf.compat import (
+    Dictionary,
+    DisplayString,
+    InnerList,
+    Item,
+    List,
+    Token,
+)
+
+
+class TestItem(unittest.TestCase):
+    def test_parse_value_and_params(self):
+        item = Item()
+        item.parse(b"foo;a=1")
+        self.assertEqual(item.value, Token("foo"))
+        self.assertEqual(dict(item.params), {"a": 1})
+
+    def test_serialise_roundtrip(self):
+        item = Item()
+        item.parse(b"foo;a=1")
+        self.assertEqual(str(item), "foo;a=1")
+
+    def test_eq_ignores_params(self):
+        item_a = Item("foo")
+        item_a.params["x"] = 1
+        item_b = Item("foo")
+        self.assertEqual(item_a, item_b)
+
+    def test_eq_to_bare_value(self):
+        item = Item(Token("foo"))
+        item.params["x"] = 1
+        self.assertEqual(item, Token("foo"))
+
+    def test_parse_error_is_valueerror(self):
+        with self.assertRaises(ValueError):
+            Item().parse(b"!!!")
+
+
+class TestList(unittest.TestCase):
+    def test_parse(self):
+        my_list = List()
+        my_list.parse(b"foo; a=1, bar; b=2")
+        self.assertEqual(len(my_list), 2)
+        self.assertEqual(my_list[0].value, Token("foo"))
+        self.assertEqual(my_list[0].params["a"], 1)
+
+    def test_contains_uses_item_equality(self):
+        my_list = List()
+        my_list.parse(b"foo;a=1, bar;b=2")
+        self.assertIn(Token("foo"), my_list)
+        self.assertEqual(my_list.count(Token("foo")), 1)
+
+    def test_append_bare_value(self):
+        my_list = List()
+        my_list.parse(b"foo;a=1")
+        my_list.append(Token("bar"))
+        self.assertEqual(my_list[-1].value, Token("bar"))
+
+    def test_append_inner_list(self):
+        my_list = List()
+        my_list.append(["x", "y"])
+        self.assertIsInstance(my_list[-1], InnerList)
+        self.assertEqual(my_list[-1][0].value, "x")
+
+    def test_serialise(self):
+        my_list = List()
+        my_list.parse(b"a, b;q=5, c")
+        self.assertEqual(str(my_list), "a, b;q=5, c")
+
+    def test_inner_list_with_params(self):
+        my_list = List()
+        my_list.append(["x", "y"])
+        my_list[-1][-1].params["a"] = True
+        self.assertEqual(str(my_list), '("x" "y";a)')
+
+
+class TestDictionary(unittest.TestCase):
+    def test_init_with_dict(self):
+        my_dict = Dictionary({"a": "1", "b": 2, "c": Token("foo")})
+        self.assertEqual(my_dict["a"].value, "1")
+        self.assertEqual(my_dict["b"].value, 2)
+        self.assertEqual(my_dict["c"].value, Token("foo"))
+
+    def test_serialise_after_param_set(self):
+        my_dict = Dictionary({"a": "1", "b": 2, "c": Token("foo")})
+        my_dict["b"].params["b1"] = 2.0
+        self.assertEqual(str(my_dict), 'a="1", b=2;b1=2.0, c=foo')
+
+    def test_parse_bare_member_is_true(self):
+        my_dict = Dictionary()
+        my_dict.parse(b"a=1, b, c;x=2")
+        self.assertEqual(my_dict["b"].value, True)
+        self.assertEqual(str(my_dict), "a=1, b, c;x=2")
+
+    def test_empty_serialisation_raises(self):
+        with self.assertRaises(ValueError):
+            str(Dictionary())
+
+
+class TestInnerList(unittest.TestCase):
+    def test_parse_via_list(self):
+        my_list = List()
+        my_list.parse(b"(1 2);a, 3")
+        self.assertIsInstance(my_list[0], InnerList)
+        self.assertEqual(my_list[0][0].value, 1)
+        self.assertEqual(my_list[0].params["a"], True)
+
+    def test_inner_list_str(self):
+        inner = InnerList(["x", Token("y")])
+        inner.params["z"] = True
+        self.assertEqual(str(inner), '("x" y);z')
+
+
+class TestTokenAndDisplayString(unittest.TestCase):
+    def test_token_constructor(self):
+        token = Token("abc")
+        self.assertEqual(str(token), "abc")
+
+    def test_display_string_roundtrip(self):
+        item = Item(DisplayString("hello"))
+        self.assertEqual(str(item), '%"hello"')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_compat_full.py
+++ b/test/test_compat_full.py
@@ -1,0 +1,187 @@
+"""Run the full JSON test suite through the http_sf.compat object API.
+
+Mirrors test/test.py but uses Dictionary/List/Item.parse() and str(...) from
+http_sf.compat, converting between functional and object forms to compare
+against the existing JSON test expectations.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any, List, Tuple
+
+from http_sf import from_json
+from http_sf.compat import (
+    Dictionary,
+    Item,
+    List as CompatList,
+    Parameters,
+    _from_functional,
+    _to_functional,
+)
+
+FAIL = "\033[91m"
+WARN = "\033[93m"
+ENDC = "\033[0m"
+
+
+def load_tests(files: Any = None) -> List[Tuple[Path, List[Any]]]:
+    suites = []
+    if not files:
+        files = Path("test/tests").glob("*.json")
+    for filename in files:
+        with open(filename, encoding="utf-8") as fh:
+            suite = from_json(fh.read())
+        suites.append((filename, suite))
+    return suites
+
+
+def _compat_parse(field_value: bytes, header_type: str) -> Any:
+    if header_type == "dictionary":
+        obj: Any = Dictionary()
+    elif header_type == "list":
+        obj = CompatList()
+    elif header_type == "item":
+        obj = Item()
+    else:
+        raise ValueError(f"Unknown header_type: {header_type}")
+    obj.parse(field_value)
+    return obj
+
+
+def _compat_to_functional(obj: Any, header_type: str) -> Any:
+    if header_type == "dictionary":
+        return {k: _to_functional(v) for k, v in obj.data.items()}
+    if header_type == "list":
+        return [_to_functional(v) for v in obj.data]
+    # item
+    return (obj.value, dict(obj.params))
+
+
+def _build_compat(expected: Any, header_type: str) -> Any:
+    if header_type == "dictionary":
+        out = Dictionary()
+        for key, val in expected.items():
+            out.data[key] = _from_functional(val)
+        return out
+    if header_type == "list":
+        out = CompatList()
+        for val in expected:
+            out.data.append(_from_functional(val))
+        return out
+    # item
+    value, params = expected
+    item = Item(value)
+    item.params = Parameters(params)
+    return item
+
+
+def test_parse(test: dict) -> Tuple[bool, Any, Any]:
+    parsed: Any = None
+    parse_success = False
+    parse_fail_reason = None
+    try:
+        field_value = b", ".join(v.encode("utf-8") for v in test["raw"])
+        obj = _compat_parse(field_value, test["header_type"])
+        parsed = _compat_to_functional(obj, test["header_type"])
+        parse_success = True
+    except ValueError as why:
+        parse_fail_reason = why.args
+        parsed = {}
+    except Exception:
+        sys.stderr.write(f"*** TEST ERROR in {test['name']}\n")
+        raise
+    if test.get("must_fail", False):
+        test_success = not parse_success
+    else:
+        test_success = test["expected"] == parsed
+    return test_success, parsed, parse_fail_reason
+
+
+def test_serialise(test: dict) -> Tuple[bool, Any, Any, Any]:
+    expected = test.get("canonical", test["raw"])
+    output: Any = None
+    ser_fail_reason = None
+    try:
+        obj = _build_compat(test["expected"], test["header_type"])
+        output = str(obj)
+    except ValueError as why:
+        ser_fail_reason = why.args[0]
+    except Exception:
+        sys.stderr.write(f"*** TEST ERROR in {test['name']}\n")
+        raise
+    if output is None:
+        test_success = expected == []
+    else:
+        test_success = expected == [output]
+    return test_success, output, expected, ser_fail_reason
+
+
+def run_suite(suite_name: str, suite: List[dict]) -> Tuple[int, int]:
+    print(f"## {suite_name}")
+    suite_tests = 0
+    suite_passed = 0
+    for test in suite:
+        suite_tests += 1
+        parse_ok, parsed, parse_reason = test_parse(test)
+        if parse_ok:
+            suite_passed += 1
+        else:
+            if test.get("can_fail", False):
+                print(
+                    f"{WARN}  * {test['name']}: PARSE FAIL (non-critical){ENDC}"
+                )
+                suite_passed += 1
+            else:
+                print(f"{FAIL}  * {test['name']}: PARSE FAIL{ENDC}")
+            print(f"    -      raw: {test['raw']}")
+            print(f"    - expected: {test.get('expected', 'FAIL')}")
+            print(f"    -      got: {parsed}")
+            if parse_reason:
+                print(f"    -   reason: {parse_reason}")
+
+        if not test.get("must_fail", False):
+            suite_tests += 1
+            ser_ok, serialised, ser_expected, ser_reason = test_serialise(test)
+            if ser_ok:
+                suite_passed += 1
+            else:
+                if test.get("can_fail", False):
+                    print(
+                        f"{WARN} * {test['name']}: SERIALISE FAIL (non-critical){ENDC}"
+                    )
+                    suite_passed += 1
+                else:
+                    print(f"{FAIL} * {test['name']}: SERIALISE FAIL{ENDC}")
+                print(f"    - expected: {ser_expected}")
+                print(f"    -      got: ['{serialised}']")
+                if ser_reason:
+                    print(f"    -   reason: {ser_reason}")
+
+    print(f"-> {suite_passed} of {suite_tests} passed.")
+    print()
+    return suite_tests, suite_passed
+
+
+if __name__ == "__main__":
+    import argparse
+
+    argparser = argparse.ArgumentParser(
+        description="Run tests through http_sf.compat."
+    )
+    argparser.add_argument(
+        "files",
+        metavar="filename",
+        type=str,
+        nargs="*",
+        help="a JSON file containing tests",
+    )
+    args = argparser.parse_args()
+    total_tests = 0
+    total_passed = 0
+    for filename, suite in load_tests(args.files):
+        tests, passed = run_suite(filename, suite)
+        total_tests += tests
+        total_passed += passed
+    print(f"TOTAL: {total_passed} of {total_tests} passed.")
+    if total_passed < total_tests:
+        sys.exit(1)


### PR DESCRIPTION
Provides Dictionary, List, Item, InnerList, Parameters classes that mirror the deprecated http_sfv package's object-oriented API, built on top of http-sf's functional parse/ser. Existing http_sfv code can typically migrate by changing only its imports, easing the path off the deprecated package.

Includes a test suite covering parse/serialise round-trips, Item value-only equality, inner-list coercion, dictionary parameter updates, and error behaviour. README gains a short migration section.